### PR TITLE
Add arg for max image width: --image-max-width

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 # Setup
 
-    $ pip install Pillow
+### Using pipenv shell
+https://stackoverflow.com/a/49867443/2159808
+```
+$ pipenv install
+$ pipenv shell
+```
+
+### By hand
+```
+$ pip install Pillow
+```
+
 
 # Usage
 


### PR DESCRIPTION
I found percentage option limiting if I simply wanted to use an EPUB for my own reader which doesn't do resizing so I decided to add max width resizing mechanism.
I added it in a way that it would work with previous percentage resizing code.